### PR TITLE
fix(yahoo): Use cURL to bypass cookie consent page

### DIFF
--- a/src/financials_yahoo.py
+++ b/src/financials_yahoo.py
@@ -17,6 +17,7 @@ import pprint
 import re
 import time
 import urllib.parse
+import subprocess
 from http import cookiejar
 
 import dateutil.parser
@@ -126,7 +127,12 @@ class Yahoo(BaseClient):
                    ]
 
         try:
-            text = self.urlopen(url, redirect=True, data=None, headers=None, cookies=cookies)
+            #text = self.urlopen(url, redirect=True, data=None, headers=None, cookies=cookies)
+
+            # Somehow cURL manages to bypass the cookie consent page from Yahoo
+            # with its user agent. How could we call urlopen() in the same way
+            # so that it behaves like cURL?
+            text = subprocess.check_output("curl " + url, stderr=subprocess.DEVNULL, shell=True)
         except BaseException as e:
             logger.exception("BaseException ticker=%s datacode=%s", ticker, datacode)
             return 'Yahoo.getRealtime({}, {}) - urlopen: {}'.format(ticker, datacode, e)

--- a/src/test_ft.py
+++ b/src/test_ft.py
@@ -208,7 +208,7 @@ class Test(unittest.TestCase):
 
         s = financials.getRealtime('SAPX:GER', 'INDUSTRY', 'FT')
         self.assertEqual(str, type(s), 'test_DE_equity INDUSTRY {}'.format(s))
-        self.assertEqual('Software & Computer Services', s, 'test_DE_equity INDUSTRY {}'.format(s))
+        self.assertEqual('Software and Computer Services', s, 'test_DE_equity INDUSTRY {}'.format(s))
 
         s = financials.getRealtime('SAPX:GER', 'LAST_PRICE_DATE', 'FT')
         self.assertEqual(str, type(s), 'test_DE_equity LAST_PRICE_DATE {}'.format(s))
@@ -243,7 +243,7 @@ class Test(unittest.TestCase):
         self.assertTrue(testutils.is_date(s), 'test_DE_equity EX_DIV_DATE {}'.format(s))
 
         s = financials.getRealtime('ISHAX:GER', 'NAME', 'FT')
-        self.assertEqual('Intershop Communications AG', s, 'test_DE_equity NAME {}'.format(s))
+        self.assertEqual('INTERSHOP Communications AG', s, 'test_DE_equity NAME {}'.format(s))
 
         s = financials.getRealtime('ISHAX:GER', 'BETA', 'FT')
         self.assertTrue(testutils.is_positive_float(s), 'test_DE_equity BETA {}'.format(s))
@@ -275,7 +275,7 @@ class Test(unittest.TestCase):
 
         s = financials.getRealtime('NOVO B:CPH', 'industry', 'FT')
         self.assertEqual(str, type(s), 'test_DK_equity INDUSTRY {}'.format(s))
-        self.assertEqual('Pharmaceuticals & Biotechnology', s, 'test_DK_equity INDUSTRY {}'.format(s))
+        self.assertEqual('Pharmaceuticals and Biotechnology', s, 'test_DK_equity INDUSTRY {}'.format(s))
 
     def test_TY_equity(self):
         s = financials.getRealtime('6503:TYO', 'OPEN', 'FT')
@@ -340,7 +340,7 @@ class Test(unittest.TestCase):
 
         s = financials.getRealtime('DELT:TLV', 'SECTOR', 'FT')
         self.assertEqual(str, type(s), 'test_TlV_equity SECTOR {}'.format(s))
-        self.assertEqual('Consumer Goods', s, 'test_TY_equity SECTOR {}'.format(s))
+        self.assertEqual('Consumer Discretionary', s, 'test_TY_equity SECTOR {}'.format(s))
 
         s = financials.getRealtime('DELT:TLV', 'INDUSTRY', 'FT')
         self.assertEqual(str, type(s), 'test_TlV_equity INDUSTRY {}'.format(s))


### PR DESCRIPTION
Problem: Yahoo now displays a EU cookie consent page and the scraping does not work anymore (at least for me in Europe).

The behavior of yahoo is really strange, because it seems to check the User agent of the request.
This works without any cookies:
```
curl https://finance.yahoo.com/quote/EUR=X?p=EUR=X -o test.html
```
Then test.html contains the correct price page.

Wget does not work and returns a 404???
```
wget "https://finance.yahoo.com/quote/EUR=X?p=EUR=X" 
--2022-01-06 23:24:07--  https://finance.yahoo.com/quote/EUR=X?p=EUR=X
Resolving finance.yahoo.com (finance.yahoo.com)... 188.125.89.204, 188.125.89.206, 2a00:1288:f03d:1fa::4000, ...
Connecting to finance.yahoo.com (finance.yahoo.com)|188.125.89.204|:443... connected.
HTTP request sent, awaiting response... 404 Not Found
2022-01-06 23:24:08 ERROR 404: Not Found.
```
But then when I fake the User agent to look like cURL it works:
```
wget -U "curl/7.74.0" "https://finance.yahoo.com/quote/EUR=X?p=EUR=X" 
--2022-01-06 23:24:51--  https://finance.yahoo.com/quote/EUR=X?p=EUR=X
Resolving finance.yahoo.com (finance.yahoo.com)... 188.125.89.206, 188.125.89.204, 2a00:1288:f03d:1fa::4000, ...
Connecting to finance.yahoo.com (finance.yahoo.com)|188.125.89.206|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: unspecified [text/html]
Saving to: ‘EUR=X?p=EUR=X’

EUR=X?p=EUR=X                                                     [  <=>                                                                                                                                            ] 716,47K  3,37MB/s    in 0,2s    

2022-01-06 23:24:53 (3,37 MB/s) - ‘EUR=X?p=EUR=X’ saved [733661]
```

So it seems like with a user agent that looks like cURL you can bypass the cookie consent wall.

I tried that with the urlopen() call in Python, but setting the cURL user agent did not work for me. As a workaround hack I just called the cURL binary from Python and then the prices work normally again for me.

How can you configure the Python HTTP client to behave the same way as CURL here?