### PR TITLE
Ignore spans with None text

### DIFF
--- a/src/financials_yahoo.py
+++ b/src/financials_yahoo.py
@@ -192,7 +192,7 @@ class Yahoo(BaseClient):
             for d in found:
                 if d:
                     span = d.find('./span')
-                    if hasattr(span, 'text'):
+                    if hasattr(span, 'text') and span.text is not None:
                         parsed[d.attrib['data-test']] = span.text.replace('−', '-').replace(',', '').strip()
                 else:
                     if hasattr(d, 'attrib') and hasattr(d, 'text'):


### PR DESCRIPTION
Thanks for all your work on this great extension! 3.2.0 fixed most of my problems with the latest yahoo update, but some tickers (FZILX and FZROX, I assume some others) aren't accessible and raise an exception. It appears that now some `span`s have a `text` attribute that's `None` in this loop. Ignoring them fixed `=GETREALTIME("FZILX", 21, "YAHOO")` for me.