### PR TITLE
Handle the case where there is a data-value but no value

### DIFF
--- a/src/financials_yahoo.py
+++ b/src/financials_yahoo.py
@@ -225,14 +225,16 @@ class Yahoo(BaseClient):
             found = root.findall(f".//fin-streamer[@data-symbol='{ticker}']")
             for d in found:
                 if hasattr(d, 'attrib') and 'data-field' in d.attrib:
-                    parsed[d.attrib['data-field']] = default(d.attrib, 'value').replace('−', '-').replace(',', '').strip()
+                    value = default(d.attrib, 'value') or default(d.attrib, 'data-value')
+                    parsed[d.attrib['data-field']] = value.replace('−', '-').replace(',', '').strip()
 
             # for futures "regularMarketVolume" is from actual future ticker (potentially different to requested one)
             if 'regularMarketVolume' not in parsed:
                 found = root.findall(f".//fin-streamer[@data-field='regularMarketVolume']")
                 for d in found:
                     if hasattr(d, 'attrib') and 'data-field' in d.attrib and 'data-symbol' in d.attrib:
-                        parsed[d.attrib['data-field']] = default(d.attrib, 'value').replace('−', '-').replace(',', '').strip()
+                        value = default(d.attrib, 'value') or default(d.attrib, 'data-value')
+                        parsed[d.attrib['data-field']] = value.replace('−', '-').replace(',', '').strip()
                         tick[Datacode.TICKER] = default(d.attrib, 'data-symbol').strip()
 
             found = root.findall(f".//td[@data-test]")


### PR DESCRIPTION
This fixes the `#N/A` issue described in #98 for me. 

Locally, I applied this and then added an extra patch doing:
```python
if value and not default(d.attrib, 'value'):
     logger.error('found data-value instead of value!')
```

And I see that from time to time in my `extension.log` file, so I am pretty confident my change is triggering and I'm not just continuously getting lucky.

I don't use futures, so I can't speak to the second instance, but I assume it's the same so I changed that as well.